### PR TITLE
different_beeps playback file has incorrect beeps

### DIFF
--- a/eddienput/gui.py
+++ b/eddienput/gui.py
@@ -420,7 +420,7 @@ class EddienputGUI(QWidget):
         self.record_to_label = QLabel()
         self.record_to_label.setText('Record to:')
         main_layout.addWidget(self.record_to_label)
-        
+
         self.record_to_line_edit = QLineEdit()
         self.record_to_line_edit.setText('recording.txt')
         main_layout.addWidget(self.record_to_line_edit)
@@ -450,7 +450,7 @@ class EddienputGUI(QWidget):
 
     def dropEvent(self, event):
         if event.mimeData().hasText:
-            event.setDropAction(Qt.CopyAction)
+            event.setDropAction(Qt.DropAction.CopyAction)
             file_path: str = event.mimeData().urls()[0].toLocalFile()
             set_playback_file(file_path)
             event.accept()

--- a/eddienput/playbacks/different_beeps.txt
+++ b/eddienput/playbacks/different_beeps.txt
@@ -1,4 +1,4 @@
 configs\gg.json
 K+beep W60
-S+beep_low W60
-H+beep_high W60
+S+beep1 W60
+H+beep3 W60


### PR DESCRIPTION
The different_beeps playback file has incorrectly labeled beeps. This causes it to be an invalid playback file. This change is to fix the beep_low and beep_high to be labeled beep1 and beep3 to match the config file.